### PR TITLE
block fix for get_bulk_payments

### DIFF
--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -1712,7 +1712,7 @@ namespace tools
     if (req.payment_ids.empty())
     {
       std::list<std::pair<crypto::hash,wallet2::payment_details>> payment_list;
-      m_wallet->get_payments(payment_list, req.min_block_height);
+      m_wallet->get_payments(payment_list, req.min_block_height - 1);
 
       for (auto & payment : payment_list)
       {


### PR DESCRIPTION
Official documentation say (`https://www.getmonero.org/resources/developer-guides/wallet-rpc.html#get_bulk_payments`):
> Inputs:
> * payment_ids - array of: string; Payment IDs used to find the payments (16 characters hex).
> * min_block_height - unsigned int; The block height at which to start looking for payments.

Here is transaction: `curl -X POST http://localhost:18083/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"get_transfer_by_txid","params":{"txid":"bb28339c6f9b6d04747d7d2a7bbb983af7ab34674404f304bdb7e3285faef67c"}}' -H 'Content-Type: application/json'`:
```json
{
  "id": "0",
  "jsonrpc": "2.0",
  "result": {
    "transfer": {
      "address": "BgyZhbSzyRc52KnrNpQZQvW3areJNtGZQ2m5UJCpTXwj3vjabgfrUSCCzMGyiXbV7SfzhU6sFDs4nER7sTafsrnE5sWQevQ",
      "amount": 1000000000000,
      "confirmations": 5,
      "double_spend_seen": false,
      "fee": 140750000,
      "height": 1230910,
      "note": "",
      "payment_id": "0000000000000000",
      "subaddr_index": {
        "major": 0,
        "minor": 16
      },
      "suggested_confirmations_threshold": 1,
      "timestamp": 1560188440,
      "txid": "bb28339c6f9b6d04747d7d2a7bbb983af7ab34674404f304bdb7e3285faef67c",
      "type": "in",
      "unlock_time": 0
    },
    "transfers": [{
      "address": "BgyZhbSzyRc52KnrNpQZQvW3areJNtGZQ2m5UJCpTXwj3vjabgfrUSCCzMGyiXbV7SfzhU6sFDs4nER7sTafsrnE5sWQevQ",
      "amount": 1000000000000,
      "confirmations": 5,
      "double_spend_seen": false,
      "fee": 140750000,
      "height": 1230910,
      "note": "",
      "payment_id": "0000000000000000",
      "subaddr_index": {
        "major": 0,
        "minor": 16
      },
      "suggested_confirmations_threshold": 1,
      "timestamp": 1560188440,
      "txid": "bb28339c6f9b6d04747d7d2a7bbb983af7ab34674404f304bdb7e3285faef67c",
      "type": "in",
      "unlock_time": 0
    },{
      "address": "BcWpgCy9W7Rb9zfxGLZassaVa3uBH92Wv6YPJFW4U7gzVrq3KPXx9cVe3cLFFRCCC8EBxfSmg9iHfG6cTSWZQAHSQ7kk8rL",
      "amount": 1275000000000,
      "confirmations": 5,
      "double_spend_seen": false,
      "fee": 140750000,
      "height": 1230910,
      "note": "",
      "payment_id": "0000000000000000",
      "subaddr_index": {
        "major": 0,
        "minor": 15
      },
      "suggested_confirmations_threshold": 1,
      "timestamp": 1560188440,
      "txid": "bb28339c6f9b6d04747d7d2a7bbb983af7ab34674404f304bdb7e3285faef67c",
      "type": "in",
      "unlock_time": 0
    },{
      "address": "BaGQP7pk8uTQRurb5pNgVHBhLVg2bLv1fD1HUQckp8PDPFyVRnmXXXcYwaMCqWgAezEBf6njizTgrUpLU7PPZAyiBiUGxa6",
      "amount": 1725000000000,
      "confirmations": 5,
      "double_spend_seen": false,
      "fee": 140750000,
      "height": 1230910,
      "note": "",
      "payment_id": "0000000000000000",
      "subaddr_index": {
        "major": 0,
        "minor": 14
      },
      "suggested_confirmations_threshold": 1,
      "timestamp": 1560188440,
      "txid": "bb28339c6f9b6d04747d7d2a7bbb983af7ab34674404f304bdb7e3285faef67c",
      "type": "in",
      "unlock_time": 0
    }]
  }
}
```
* as we see: `"height": 1230910`.
* lets call: `curl -X POST http://127.0.0.1:18083/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"get_bulk_payments","params":{"payment_ids":[],"min_block_height":1230910}}' -H 'Contnt-Type: application/json'`:
```json
{
  "id": "0",
  "jsonrpc": "2.0",
  "result": {
  }
}
```
* lets call `-1` block less `curl -X POST http://127.0.0.1:18083/json_rpc -d '{"jsonrpc":"2.0","id":"0","method":"get_bulk_payments","params":{"payment_ids":[],"min_block_height":1230909}}' -H 'Contnt-Type: application/json'`:
```json
{
  "id": "0",
  "jsonrpc": "2.0",
  "result": {
    "payments": [{
      "address": "BgyZhbSzyRc52KnrNpQZQvW3areJNtGZQ2m5UJCpTXwj3vjabgfrUSCCzMGyiXbV7SfzhU6sFDs4nER7sTafsrnE5sWQevQ",
      "amount": 1000000000000,
      "block_height": 1230910,
      "payment_id": "0000000000000000000000000000000000000000000000000000000000000000",
      "subaddr_index": {
        "major": 0,
        "minor": 16
      },
      "tx_hash": "bb28339c6f9b6d04747d7d2a7bbb983af7ab34674404f304bdb7e3285faef67c",
      "unlock_time": 0
    },{
      "address": "BcWpgCy9W7Rb9zfxGLZassaVa3uBH92Wv6YPJFW4U7gzVrq3KPXx9cVe3cLFFRCCC8EBxfSmg9iHfG6cTSWZQAHSQ7kk8rL",
      "amount": 1275000000000,
      "block_height": 1230910,
      "payment_id": "0000000000000000000000000000000000000000000000000000000000000000",
      "subaddr_index": {
        "major": 0,
        "minor": 15
      },
      "tx_hash": "bb28339c6f9b6d04747d7d2a7bbb983af7ab34674404f304bdb7e3285faef67c",
      "unlock_time": 0
    },{
      "address": "BaGQP7pk8uTQRurb5pNgVHBhLVg2bLv1fD1HUQckp8PDPFyVRnmXXXcYwaMCqWgAezEBf6njizTgrUpLU7PPZAyiBiUGxa6",
      "amount": 1725000000000,
      "block_height": 1230910,
      "payment_id": "0000000000000000000000000000000000000000000000000000000000000000",
      "subaddr_index": {
        "major": 0,
        "minor": 14
      },
      "tx_hash": "bb28339c6f9b6d04747d7d2a7bbb983af7ab34674404f304bdb7e3285faef67c",
      "unlock_time": 0
    }]
  }
}
```

testnet, Monero 'Boron Butterfly' (v0.14.0.2-release)